### PR TITLE
Device Client now uses AMQP to establish a connection with IoT Hub

### DIFF
--- a/Hanford/Device/raspberry-pi/iot-core/c-sharp/EnvironmentMonitoringApp/EnvironmentMonitoringApp/StartupTask.cs
+++ b/Hanford/Device/raspberry-pi/iot-core/c-sharp/EnvironmentMonitoringApp/EnvironmentMonitoringApp/StartupTask.cs
@@ -44,7 +44,7 @@ namespace EnvironmentMonitoringApp
 
             Debug.WriteLine(connectionString);
 
-            client = DeviceClient.CreateFromConnectionString(connectionString);
+            client = DeviceClient.CreateFromConnectionString(connectionString, Microsoft.Azure.Devices.Client.TransportType.Amqp);
 
             await weatherShield.BeginAsync();
 


### PR DESCRIPTION
Needed to add the TransportType to the connection so that DeviceClient would use AMQP.
